### PR TITLE
Fix furi crash

### DIFF
--- a/pokemon_app.cpp
+++ b/pokemon_app.cpp
@@ -124,10 +124,7 @@ extern "C" int32_t pokemon_app(void* p) {
     furi_hal_light_set(LightRed, 0x00);
     furi_hal_light_set(LightGreen, 0x00);
     furi_hal_light_set(LightBlue, 0x00);
-    view_dispatcher_enable_queue(app->view_dispatcher);
-    view_dispatcher_attach_to_gui(app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
     //switch view  and run dispatcher
-    view_dispatcher_switch_to_view(app->view_dispatcher, AppViewSelectPokemon);
     view_dispatcher_run(app->view_dispatcher);
 
     // Free resources

--- a/views/trade.cpp
+++ b/views/trade.cpp
@@ -327,6 +327,7 @@ void trade_enter_callback(void* context) {
         GpioModeInterruptRise,
         GpioPullNo,
         GpioSpeedVeryHigh); // <-- This line causes the "OK" to stop functioning when exiting the application, so a reboot of the Flipper Zero is required.
+    furi_hal_gpio_remove_int_callback(&GAME_BOY_CLK);
     furi_hal_gpio_add_int_callback(&GAME_BOY_CLK, input_clk_gameboy, trade);
 
     // furi_hal_gpio_disable_int_callback(&GAME_BOY_CLK);


### PR DESCRIPTION
Fixes #9 

Also cleans up some double function calls.

While @EstebanFuentealba and I briefly chatted about moving pins due to conflicts with Flipper firmware; this can still work (just need to reboot the Flipper Zero before using NFC again), and once the API settles in OFW 1.0 that can be a choice made then. For now, it doesn't make sense to re-do all of the photos and graphics in this repo.