### PR TITLE
Fix double free crash at app exit on TLSF

### DIFF
--- a/views/select_pokemon.c
+++ b/views/select_pokemon.c
@@ -137,6 +137,5 @@ View* select_pokemon_alloc(PokemonFap* pokemon_fap) {
 
 void select_pokemon_free(PokemonFap* pokemon_fap) {
     furi_assert(pokemon_fap);
-    view_free_model(pokemon_fap->select_view);
     view_free(pokemon_fap->select_view);
 }

--- a/views/trade.c
+++ b/views/trade.c
@@ -762,7 +762,6 @@ void trade_free(ViewDispatcher* view_dispatcher, uint32_t view_id, void* trade_c
 
     view_dispatcher_remove_view(view_dispatcher, view_id);
 
-    view_free_model(trade->view);
     view_free(trade->view);
     free(trade->input_block);
     free(trade);


### PR DESCRIPTION
View model is freed by view itself, on new upcoming TLSF allocator (some CFW already use it) double free() will cause BusFault crashes. Regardless, should not be freed anyway )